### PR TITLE
Fix npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ void main() {
 Install with npm:
 
 ```
-npm install glsl-out-of-ranges
+npm install glsl-out-of-range
 ```
 
 Then use with [glslify](https://github.com/stackgl/glslify).


### PR DESCRIPTION
The package name is `glsl-out-of-range`. `glsl-out-of-ranges` is not owned by us.

@archmoj Please review (and feel free to merge if you agree with this change).